### PR TITLE
Remove loopback-connector-db2 from Third Party section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@
   * IndustrialCloudSolutions - [loopback-connector-kafka](https://github.com/IndustrialCloudSolutions/loopback-connector-kafka)
   * haio - [loopback-connector-kafka](https://github.com/haio/loopback-connector-kafka)
 * austinsc - [loopback-connector-ravendb](https://github.com/austinsc/loopback-connector-ravendb)
-* ramyaraji - [loopback-connector-db2](https://github.com/ramyaraji/loopback-connector-db2)
 * ecowden - [loopback-connector-knex](https://github.com/ecowden/loopback-connector-knex)
 * Synerzip - [loopback-connector-redis](https://github.com/Synerzip/loopback-connector-redis)
 * timosaikkonen - [loopback-connector-solr](https://github.com/timosaikkonen/loopback-connector-solr)


### PR DESCRIPTION
The link is broken, and the github user has removed all public repositories.